### PR TITLE
Update esp32-hal-ledc.c

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -315,7 +315,7 @@ void ledcAttachPin(uint8_t pin, uint8_t chan)
 #if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32C3
     pinMatrixOutAttach(pin, LEDC_LS_SIG_OUT0_IDX + chan, false, false);
 #else
-    pinMatrixOutAttach(pin, ((chan/8)?LEDC_LS_SIG_OUT0_IDX:LEDC_HS_SIG_OUT0_IDX) + (chan%8), false, false);
+    pinMatrixOutAttach(pin, ((chan/8)?LEDC_HS_SIG_OUT0_IDX:LEDC_LS_SIG_OUT0_IDX) + (chan%8), false, false);
 #endif
 }
 


### PR DESCRIPTION
IN LINE 209:
if(group) {
        LEDC_CHAN(group, channel).conf0.low_speed_update = 1;}
->group 1 is a LOW speed group.

BUT WHY IN LINE 319:
(chan/8)?LEDC_LS_SIG_OUT0_IDX:LEDC_HS_SIG_OUT0_IDX) ?
->group 1 is a HIGH speed group.

I think there is a conflick